### PR TITLE
Deal with a 'slow_sites' table

### DIFF
--- a/lib/sprouter/adjust.rb
+++ b/lib/sprouter/adjust.rb
@@ -17,6 +17,7 @@ module Sprouter
 
     def run!
       update_turbo_sites
+      update_slow_sites
       update_turbo_hosts
     end
 
@@ -28,6 +29,11 @@ module Sprouter
     def update_turbo_sites
       turbo_site_ips = lookup_ips(config.turbo_sites)
       pf.set_table "turbo_sites", turbo_site_ips
+    end
+
+    def update_slow_sites
+      slow_site_ips = lookup_ips(config.slow_sites)
+      pf.set_table "slow_sites", slow_site_ips
     end
 
     def lookup_ips(hostnames)

--- a/lib/sprouter/config.rb
+++ b/lib/sprouter/config.rb
@@ -13,6 +13,11 @@ module Sprouter
       deep_values("turbo_sites")
     end
 
+    # Domain names of sites that should never go over the fast link.
+    def slow_sites
+      deep_values("slow_sites")
+    end
+
     # IP addresses of local machines that should always get to use the fast link.
     def turbo_hosts
       deep_values("turbo_hosts")

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -47,6 +47,10 @@ describe Sprouter::Config do
         - github.com
         - gist.github.com
 
+      slow_sites:
+        bizarre:
+        - www.catb.org
+
       turbo_hosts:
         mine:
         - 172.16.0.1
@@ -74,6 +78,7 @@ describe Sprouter::Config do
           below: 0.2
     YAML
     it { expect(config.turbo_sites).to eq(["www.google.com", "github.com", "gist.github.com"]) }
+    it { expect(config.slow_sites).to eq(["www.catb.org"]) }
     it { expect(config.turbo_hosts).to eq(["172.16.0.1", "172.16.0.2", "172.16.0.3"]) }
     it { expect(config.preferred_hosts).to eq(["172.16.0.11", "172.16.0.12", "172.16.0.13"]) }
     it { expect(config.go_faster).to be_a(Sprouter::PingCheck) }


### PR DESCRIPTION
Some sites use a lot of bandwidth but don't actually need to be fast.
